### PR TITLE
rjags removal and sampling fix

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -111,7 +111,15 @@ degMB <-
 {
     delen <- length(tags)
     g <- ""
-    rand <- sample(row.names(counts),pop)
+    # if counts is tiny, sample with replacement
+    if(nrow(counts) < pop) {
+        warning("The number of genes < samples requested, sampling with replacement.")
+        replace = TRUE
+    }
+    else {
+        replace = FALSE
+    }
+    rand <- sample(row.names(counts),pop, replace=replace)
     g1var <- apply(counts[tags,g1,drop=FALSE],1,mean)    
     g2var <- apply(counts[tags,g2,drop=FALSE],1,mean)    
   
@@ -149,6 +157,14 @@ degVB <-
 {
     delen <- length(tags)
     g <- ""
+    # if counts is tiny, sample with replacement
+    if(nrow(counts) < pop) {
+        warning("The number of genes < samples requested, sampling with replacement.")
+        replace = TRUE
+    }
+    else {
+        replace = FALSE
+    }
     rand <- sample(row.names(counts),pop)
     g1var <- apply(counts[tags,g1,drop=FALSE],1,sd)    
     g2var <- apply(counts[tags,g2,drop=FALSE],1,sd)    


### PR DESCRIPTION
Hi Lorena,

It didn't look like jags was being used, and it was causing DEGReport to not be able to be run, so I removed it. I also added a fix for if you have a situation where you have a small number of genes and are asking for more samples than genes; this can happen for like test data. When that happens, a warning gets raised and it switches the sampling to be with replacement. Let me know what you think and if you think that is a reasonable solution.
