### PR TITLE
Fix for missing factor observations when summarizing in DEGpattern

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -1004,9 +1004,13 @@ degPatterns = function(ma, metadata, minc=15, summarize="merge",
         col = "colored"
         metadata[,col] = rep("one_group", nrow(metadata))
     }
+
     if (!summarize %in% names(metadata))
         metadata[,summarize] = as.factor(paste0(metadata[,col],
                                                 metadata[,time]))
+
+    # ensure there are no missing levels in summarize
+    metadata[,summarize] = droplevels(metadata[,summarize])
 
     stopifnot(class(metadata) == "data.frame")
     stopifnot(class(ma) == "matrix" | class(ma) == "data.frame")

--- a/tests/testthat/test_cluster.R
+++ b/tests/testthat/test_cluster.R
@@ -17,6 +17,13 @@ test_that("cluster_plot", {
     expect_is(degPlotCluster(res$normalized, "group", "other"), "gg")
 })
 
+test_that("missingfactor", {
+   des_missing <- des
+   levels(des_missing$group) <- c(levels(des_missing$group), "missing")
+   expect_is(degPatterns(ma, des_missing, time="group", col = NULL, plot = FALSE,
+                         summarize="group"), "list")
+})
+
 test_that("transform", {
     expect_gte(mean(.scale(counts(dse)[1,])), -0.5)
     expect_lte(mean(.scale(counts(dse)[1,])), 0.5)


### PR DESCRIPTION
DEGpattern with summarize set to an existing entry in the metadata matrix will throw an error if there are levels with no observations. You can see this behavior by running the test before the fix. The fix just drops any factor levels with missing observations before continuing.